### PR TITLE
Add basic Archlinux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install Bats:
     $ git clone https://github.com/sstephenson/bats.git
     $ cd bats
     $ [sudo] ./install.sh /usr/local
-    
+
 Run the tests with:
 
     bats test

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ cat <<EOF
   e.g. $0 -i /data/chroot
 
   Install the lx-brand guest tools for a given installation path.
-  
+
   OPTIONS:
   -i The path to the given Linux installation
   -h Show this message
@@ -62,7 +62,7 @@ install_tools() {
   info "Creating symlinks for binaries found in /native"
 
   SYMLINKS=$(cat ./src/symlinks.txt)
-  
+
   # Note Values for ${binary} must be the full path
   for binary in $SYMLINKS; do
     if [[ ! -e $INSTALL_DIR${binary} && ! -L $INSTALL_DIR${binary} ]]; then
@@ -71,27 +71,27 @@ install_tools() {
       info "Binary ${binary} exits in installation. Skipping symlink creation."
     fi
   done
-  
+
   info "Copying native_manpath.sh to $INSTALL_DIR/etc/profile.d/"
   cp ./src/etc/profile.d/native_manpath.sh $INSTALL_DIR/etc/profile.d/
-  
+
   info "Copying ./src/lib/smartdc to $INSTALL_DIR/lib/"
   cp -r ./src/lib/smartdc $INSTALL_DIR/lib/
 }
 
 install_debian() {
   install_tools
-  
+
   info "Installing custom rc.local file to $INSTALL_DIR/etc/rc.local..."
   cp ./src/lib/smartdc/joyent_rc.local $INSTALL_DIR/etc/rc.local
 }
 
 install_redhat() {
   install_tools
-  
+
   info "Installing custom rc.local file to $INSTALL_DIR/etc/rc.d/rc.local..."
   cp ./src/lib/smartdc/joyent_rc.local $INSTALL_DIR/etc/rc.d/rc.local
-  
+
   # On CentOS 7 systemd is the default.
   # make /etc/rc.d/rc.local executable to enable rc.local Compatibility unit
   chmod 755 $INSTALL_DIR/etc/rc.d/rc.local
@@ -99,14 +99,31 @@ install_redhat() {
 
 install_alpine() {
   install_tools
-  
+
   info "Installing custom rc.local file to $INSTALL_DIR/etc/rc.local..."
   cp ./src/lib/smartdc/joyent_rc.local $INSTALL_DIR/etc/local.d/joyent.start
   chmod +x $INSTALL_DIR/etc/local.d/joyent.start
-  
+
   info "Installing shutdown wrapper script"
   cp ./src/sbin/shutdown $INSTALL_DIR/sbin/
-  
+
+}
+
+install_arch() {
+  install_tools
+
+  info "Installing custom rc.local file to $INSTALL_DIR/etc/rc.d/rc.local..."
+  if [[ ! -d $INSTALL_DIR/etc/systemd/system ]] ; then
+    mkdir -p $INSTALL_DIR/etc/systemd/system
+  fi
+
+  cp ./src/etc/systemd/system/joyent.service \
+    $INSTALL_DIR/etc/systemd/system/joyent.service
+
+  # activate joyent systemd unit
+  # XXX do that via systemctl in the chroot?
+  ln -sf /etc/systemd/system/joyent.service \
+    $INSTALL_DIR/etc/systemd/system/multi-user.target.wants/joyent.service
 }
 
 ## MAIN ##
@@ -121,6 +138,8 @@ case $OS in
       install_debian
     elif [[ -f $INSTALL_DIR/etc/alpine-release ]] ; then
       install_alpine
+    elif [[ -f $INSTALL_DIR/etc/arch-release ]] ; then
+      install_arch
     else
       fatal "Sorry. Your OS ($OS) is not supported."
     fi

--- a/src/etc/systemd/system/joyent.service
+++ b/src/etc/systemd/system/joyent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Joyent specific setup
+ConditionPathExists=/lib/smartdc/joyent_rc.local
+
+[Service]
+Type=oneshot
+ExecStart=/lib/smartdc/joyent_rc.local
+TimeoutSec=0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/src/lib/smartdc/archlinux
+++ b/src/lib/smartdc/archlinux
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2015, Joyent, Inc. All rights reserved.
+#
+# Archlinux specific setup
+
+# load common functions and vars
+. /lib/smartdc/common.lib

--- a/src/lib/smartdc/joyent_rc.local
+++ b/src/lib/smartdc/joyent_rc.local
@@ -21,6 +21,8 @@ case $(uname -s | tr '[:upper:]' '[:lower:]') in
       /lib/smartdc/redhat
     elif [[ -f /etc/alpine-release ]] ; then
       /lib/smartdc/alpine
+    elif [[ -f /etc/arch-release ]] ; then
+      /lib/smartdc/archlinux
     fi
     ;;
   *)


### PR DESCRIPTION
This adds `install.sh` and `joyent_rc.local` support for Archlinux.
This also adds a systemd unit file for the `joyent_rc.local` script.
