### PR TITLE
User script logging

### DIFF
--- a/src/lib/smartdc/common.lib
+++ b/src/lib/smartdc/common.lib
@@ -6,7 +6,9 @@
 # location of binaries and files that functions use
 LOGGER=$(which logger 2> /dev/null)
 LOG='/var/log/triton.log'
-touch $LOG
+if [[ ! -e $LOG ]]; then
+  touch $LOG
+fi
 exec 4<> $LOG
 export PS4='[\D{%FT%TZ}] ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 export BASH_XTRACEFD=4

--- a/src/lib/smartdc/mdata-execute
+++ b/src/lib/smartdc/mdata-execute
@@ -20,7 +20,11 @@ fi
 user_script_exit=0
 if [[ -x /var/svc/mdata-user-script ]]; then
   smartdc_info "Executing metadata user-script"
-  /var/svc/mdata-user-script
+  USER_SCRIPT_LOG=/var/log/mdata-user-script.log
+  if [[ ! -e $USER_SCRIPT_LOG ]]; then
+    touch $USER_SCRIPT_LOG
+  fi
+  /var/svc/mdata-user-script >> $USER_SCRIPT_LOG 2>&1
   [[ $? -gt 0 ]] && user_script_exit=95
 fi
 


### PR DESCRIPTION
Log output of mdata-user-script to /var/log/mdata-user-script.log. Fixes #22

Also: Only create $LOG in common.lib if it doesn't already exist