### PR TITLE
Add gentoo support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ if [[ ! -e "$INSTALL_DIR" ]] ; then
   exit 1
 fi
 
-install_tools() {
+install_symlinks() {
   info "Creating symlinks for binaries found in /native"
 
   SYMLINKS=$(cat ./src/symlinks.txt)
@@ -66,11 +66,16 @@ install_tools() {
   # Note Values for ${binary} must be the full path
   for binary in $SYMLINKS; do
     if [[ ! -e $INSTALL_DIR${binary} && ! -L $INSTALL_DIR${binary} ]]; then
-      chroot $INSTALL_DIR ln -s /native${binary} ${binary}
+      mkdir -p "$(dirname "$INSTALL_DIR${binary}")"
+      ln -s /native${binary} "$INSTALL_DIR${binary}"
     else
       info "Binary ${binary} exits in installation. Skipping symlink creation."
     fi
   done
+}
+
+install_tools() {
+  install_symlinks
 
   info "Copying native_manpath.sh to $INSTALL_DIR/etc/profile.d/"
   cp ./src/etc/profile.d/native_manpath.sh $INSTALL_DIR/etc/profile.d/

--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,24 @@ install_arch() {
     $INSTALL_DIR/etc/systemd/system/multi-user.target.wants/joyent.service
 }
 
+install_gentoo() {
+  install_symlinks
+
+  info "Copying sdc-vmtools to $INSTALL_DIR/etc/env.d/"
+  mkdir -p "$INSTALL_DIR/etc/env.d/"
+  cp ./src/env.d/99sdc-vmtools "$INSTALL_DIR/etc/env.d/"
+
+  info "Copying ./src/lib/smartdc to $INSTALL_DIR/lib/"
+  mkdir -p "$INSTALL_DIR/lib/"
+  cp -r ./src/lib/smartdc "$INSTALL_DIR/lib/"
+
+  info "Installing sdc-init file to $INSTALL_DIR/etc/init.d/"
+  mkdir -p "$INSTALL_DIR/etc/init.d/"
+  cp ./src/etc/init.d/sdc-init "$INSTALL_DIR/etc/init.d/"
+  chmod +x "$INSTALL_DIR/etc/init.d/sdc-init"
+}
+
+
 ## MAIN ##
 
 OS=$(uname -s)
@@ -154,6 +172,8 @@ case $OS in
       install_debian
     elif [[ -f $INSTALL_DIR/etc/alpine-release ]] ; then
       install_alpine
+    elif [[ -f $INSTALL_DIR/etc/gentoo-release ]] ; then
+      install_gentoo
     elif [[ -f $INSTALL_DIR/etc/void-release ]] ; then
       install_void
     elif [[ -f $INSTALL_DIR/etc/arch-release ]] ; then

--- a/src/env.d/99sdc-vmtools
+++ b/src/env.d/99sdc-vmtools
@@ -1,0 +1,1 @@
+MANPATH=/native/usr/share/man

--- a/src/etc/init.d/sdc-init
+++ b/src/etc/init.d/sdc-init
@@ -1,0 +1,13 @@
+#!/sbin/openrc-run
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+description="Initializes the zone"
+
+start()
+{
+	ebegin "Initializing Zone"
+	/lib/smartdc/joyent_rc.local
+	eend $?
+}

--- a/src/lib/smartdc/generate-resolv
+++ b/src/lib/smartdc/generate-resolv
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Joyent, Inc.
+#
+# Configure resolv.conf  if not set
+
+set -eu -o pipefail
+
+if [[ ! -e /etc/resolv.conf ]]; then
+  RESOLV=$(mktemp)
+
+  echo "# AUTOMATIC ZONE CONFIG" > "$RESOLV"
+  for i in $(mdata-get sdc:resolvers | jq -r .[]); do
+    echo "nameserver $i" >> "$RESOLV"
+  done
+  
+  chmod 644 "$RESOLV"
+
+  mv "$RESOLV" /etc/resolv.conf 
+fi

--- a/src/lib/smartdc/gentoo
+++ b/src/lib/smartdc/gentoo
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Joyent, Inc.
+#
+# Gentoo specific setup
+#
+
+# load common functions and vars
+. /lib/smartdc/common.lib
+
+#  Configure resolv.conf  if not set
+/lib/smartdc/generate-resolv

--- a/src/lib/smartdc/joyent_rc.local
+++ b/src/lib/smartdc/joyent_rc.local
@@ -28,6 +28,8 @@ case $(uname -s | tr '[:upper:]' '[:lower:]') in
       /lib/smartdc/redhat
     elif [[ -f /etc/alpine-release ]] ; then
       /lib/smartdc/alpine
+    elif [[ -f /etc/gentoo-release ]] ; then
+      /lib/smartdc/gentoo
     elif [[ -f /etc/void-release ]] ; then
       /lib/smartdc/void
     elif [[ -f /etc/arch-release ]] ; then

--- a/src/lib/smartdc/void
+++ b/src/lib/smartdc/void
@@ -4,13 +4,10 @@
 #
 # Void specific setup
 #
+
 #  Configure resolv.conf  if not set
-if [[ ! -e /etc/resolv.conf ]]; then
-  echo "# AUTOMATIC ZONE CONFIG" > /etc/resolv.conf
-  for i in $(mdata-get sdc:resolvers | jq -r .[]); do
-    echo "nameserver $i" >> /etc/resolv.conf
-  done
-fi
+/lib/smartdc/generate-resolv
+
 # void attempts to write to `/proc/sys/kernel/hostname` which is currently
 # unsupported in LX zones.  Until that is supported, this logic will work to
 # set the hostname at boot.


### PR DESCRIPTION
This CL adds support for installing into gentoo. The script to build an image is here: https://github.com/ismell/gentoo-lx-brand-image-builder

This image is currently [pointing](https://github.com/ismell/gentoo-lx-brand-image-builder/blob/master/root/var/db/repos/local/sys-apps/sdc-vmtools/sdc-vmtools-9999.ebuild#L19) to my sdc-vmtools fork. Once this patch lands I can update the ebuild to point to the official source.